### PR TITLE
Fixed Double-Push bug

### DIFF
--- a/chat-history.js
+++ b/chat-history.js
@@ -65,11 +65,20 @@ const chatHistory = async (chat) => {
   console.log( `${hours}:${mins} - [${lastIdofMsgs}]`)
 }
 
+let sent = []
+
 const sendToServer = async (messages) => {
+	let toPush = messages.filter(m => {
+		return sent.indexOf( m ) < 0;
+	})
+	messages.forEach(m => {
+		sent.push(m.id)
+	});
+	console.log(sent);
   const response = await fetch(config.server,
     {
       method: 'POST',
-      body: JSON.stringify(messages),
+      body: JSON.stringify(toPush),
       headers: { "Content-Type": "application/json" }
     })
   const json = await response.json();

--- a/chat-history.js
+++ b/chat-history.js
@@ -74,7 +74,6 @@ const sendToServer = async (messages) => {
 	messages.forEach(m => {
 		sent.push(m.id)
 	});
-	console.log(sent);
   const response = await fetch(config.server,
     {
       method: 'POST',


### PR DESCRIPTION
Fixed a bug that caused it to push the same messages twice when multiple messages are received in the same scan interval

UPDATE: Removed unnecessary `console.log()`